### PR TITLE
Remove Blog links from navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a class="active-link" href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/blog/index.html
+++ b/blog/index.html
@@ -13,7 +13,6 @@
             <li><a href="../index.html">Work</a></li>
             <li><a href="../about.html">About</a></li>
             <li><a href="../contact.html">Contact</a></li>
-            <li><a class="active-link" href="index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/blog/posts/2025-06-01-welcome.html
+++ b/blog/posts/2025-06-01-welcome.html
@@ -13,7 +13,6 @@
             <li><a href="../../index.html">Work</a></li>
             <li><a href="../../about.html">About</a></li>
             <li><a href="../../contact.html">Contact</a></li>
-            <li><a class="active-link" href="../index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/contact.html
+++ b/contact.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a class="active-link" href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
             <li><a class="active-link" href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/project-1.html
+++ b/project-1.html
@@ -13,7 +13,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/project-abled.html
+++ b/project-abled.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/project-makeful.html
+++ b/project-makeful.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/project-mrkate.html
+++ b/project-mrkate.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/project-redwood-rebrand.html
+++ b/project-redwood-rebrand.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>

--- a/project-sarahsilverman.html
+++ b/project-sarahsilverman.html
@@ -22,7 +22,6 @@
             <li><a href="index.html">Work</a></li>
             <li><a href="about.html">About</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><a href="blog/index.html">Blog</a></li>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
## Summary
- remove the Blog link from navigation menus on all pages

## Testing
- `grep -R "Blog" -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685f39aa32c883239f8b9076e7d5367e