### PR TITLE
Remove emojis from website pages

### DIFF
--- a/ai-sales-coach.html
+++ b/ai-sales-coach.html
@@ -97,17 +97,14 @@
       <!-- Value bullets -->
       <div class="grid gap-4 max-w-5xl mx-auto mb-12 center-grid md:grid-cols-3 md:place-items-stretch">
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl mb-2">📞</div>
           <h3 class="font-semibold mb-1">Prospecting and follow-up</h3>
           <p class="text-white/70 text-sm">Practice that mirrors your market with realistic objections and scenario prompts.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl mb-2">🧠</div>
           <h3 class="font-semibold mb-1">Listing presentations</h3>
           <p class="text-white/70 text-sm">Run simulations and rehearse objection handling until it sticks.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl mb-2">✍️</div>
           <h3 class="font-semibold mb-1">Reusable copy blocks</h3>
           <p class="text-white/70 text-sm">Snippets reps can reuse in emails, texts, and DMs.</p>
         </div>
@@ -128,22 +125,18 @@
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-12 balance mx-auto h-measure leading-tight">How It Works</h2>
       <div class="grid gap-6 center-grid md:grid-cols-4 md:place-items-stretch">
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">📄</div>
           <h3 class="font-semibold mt-2">1. Upload scripts</h3>
           <p class="text-white/70 text-sm">Your buyer and seller scripts, talk tracks, and local language.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🎛️</div>
           <h3 class="font-semibold mt-2">2. Select scenarios</h3>
           <p class="text-white/70 text-sm">Pick prospect types and objections you want reps to master.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🤖</div>
           <h3 class="font-semibold mt-2">3. Practice with AI</h3>
           <p class="text-white/70 text-sm">Agents role-play any time. Immediate feedback. No calendar juggling.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">📈</div>
           <h3 class="font-semibold mt-2">4. Review and improve</h3>
           <p class="text-white/70 text-sm">Track strengths, gaps, and next reps to coach.</p>
         </div>
@@ -157,17 +150,14 @@
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-12 balance mx-auto h-measure leading-tight">Why Teams Use This</h2>
       <div class="grid gap-6 center-grid md:grid-cols-3 md:place-items-stretch">
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">⚡</div>
           <h3 class="font-semibold mt-2">Faster ramp</h3>
           <p class="text-white/70 text-sm">New reps practice day one. Less shadowing. Less babysitting.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🛡️</div>
           <h3 class="font-semibold mt-2">Consistent messaging</h3>
           <p class="text-white/70 text-sm">Your scripts and brand voice loaded into every simulation.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🧩</div>
           <h3 class="font-semibold mt-2">Modular and private</h3>
           <p class="text-white/70 text-sm">Bring your data, keep your data. Simple setup.</p>
         </div>
@@ -188,7 +178,7 @@
       <div class="grid gap-8 center-grid md:grid-cols-2 md:place-items-stretch">
         <!-- Real Estate Teams -->
         <div class="card glass rounded-2xl p-6">
-          <div class="flex items-center gap-3 mb-4 text-lg"><span>🏠</span><span class="font-semibold">Real Estate Teams</span></div>
+          <div class="mb-4 text-lg"><span class="font-semibold">Real Estate Teams</span></div>
           <div class="grid md:grid-cols-2 gap-4">
             <div>
               <p class="text-xs uppercase tracking-wide text-white/60">The challenge</p>
@@ -202,7 +192,7 @@
         </div>
         <!-- New Agents & ISAs -->
         <div class="card glass rounded-2xl p-6">
-          <div class="flex items-center gap-3 mb-4 text-lg"><span>🧩</span><span class="font-semibold">New Agents & ISAs</span></div>
+          <div class="mb-4 text-lg"><span class="font-semibold">New Agents & ISAs</span></div>
           <div class="grid md:grid-cols-2 gap-4">
             <div>
               <p class="text-xs uppercase tracking-wide text-white/60">The challenge</p>

--- a/ai-usage.html
+++ b/ai-usage.html
@@ -60,37 +60,37 @@
 
   <p>In each principle I’ll use a simple example from building a web app with AI. These aren’t hard rules. They’re practical guardrails that keep the work real and useful.</p>
 
-  <h3>⚠️ Principle 1: Know Enough to Spot Wrong</h3>
+  <h3>Principle 1: Know Enough to Spot Wrong</h3>
   <p>If you can’t tell whether the AI is right or wrong, don’t use it for that task. AI can sound certain while being off. Misuse shows up when people ask for answers in domains they don’t understand.</p>
   <blockquote><strong>Trust requires judgment.</strong> If you can’t recognize an error, you’re not ready to use the tool for that task.</blockquote>
   <h4>Example:</h4>
   <p>If you ask AI to build a web app and it picks Django instead of something like React + Node, would you even know the difference? If not, you might be building the wrong kind of application.</p>
 
-  <h3>🛠️ Principle 2: Experiment Freely, Ship Carefully</h3>
+  <h3>Principle 2: Experiment Freely, Ship Carefully</h3>
   <p>Play with AI. Try things. Break things. That’s how you learn. When you ship to production, especially if others will rely on it, you own the quality.</p>
   <blockquote><strong>Curiosity is encouraged. Irresponsibility isn’t.</strong></blockquote>
   <h4>Example:</h4>
   <p>Using AI to generate a login form is fine. Copy-pasting that code into a live app without understanding authentication or password hashing is a risk multiplier for your team and users.</p>
 
-  <h3>🧠 Principle 3: AI Isn’t a Brain. You Are.</h3>
+  <h3>Principle 3: AI Isn’t a Brain. You Are.</h3>
   <p>AI is pattern completion at scale. It doesn’t reason like a human. You bring strategy, ethics, and goals. It’ll follow your direction, even if your direction is flawed.</p>
   <blockquote><strong>You can’t delegate decisions to a tool that doesn’t understand context.</strong></blockquote>
   <h4>Example:</h4>
   <p>If you say “build me a booking system,” AI will start spitting out components. Only you can define what it needs: time zones, cancellation rules, capacity, audit trails. That’s on you.</p>
 
-  <h3>🧭 Principle 4: Clarity In, Clarity Out</h3>
+  <h3>Principle 4: Clarity In, Clarity Out</h3>
   <p>Results track your ask. AI mirrors your input. Give context, constraints, and acceptance criteria if you want dependable output.</p>
   <blockquote><strong>Be specific. Be intentional. The prompt is the project.</strong></blockquote>
   <h4>Example:</h4>
   <p>“Build me a budgeting app” gets you something vague. “Build a React app that lets users input income and expenses, save them locally, and export to CSV” gets you something usable.</p>
 
-  <h3>⏳ Principle 5: Don’t Skip the Thinking</h3>
+  <h3>Principle 5: Don’t Skip the Thinking</h3>
   <p>AI moves fast. It won’t think for you. If you don’t define goals, architecture, and edge cases, you’re just speeding into confusion.</p>
   <blockquote><strong>AI can amplify your vision, but it can’t replace it.</strong></blockquote>
   <h4>Example:</h4>
   <p>You ask AI for a dashboard. It returns a beautiful UI. There’s no data validation, no state management, no business logic. You never asked for those because you skipped the thinking.</p>
 
-  <h3>🤝 Principle 6: Collaborate With It, Don’t Delegate Blindly</h3>
+  <h3>Principle 6: Collaborate With It, Don’t Delegate Blindly</h3>
   <p>Treat AI like a fast partner. Ask questions, test ideas, and iterate. Collaboration beats one-shot delegation.</p>
   <blockquote><strong>Use it as a sharp assistant, not an expert builder.</strong></blockquote>
   <h4>Example:</h4>

--- a/contact.html
+++ b/contact.html
@@ -32,9 +32,9 @@
 <div class="">
     <h3>Let's Make Something Amazing Together</h3>
     <p class="about-paragraph">Have a project in mind? Ready to elevate your brand's story? I'm just a call or an email away from turning your vision into reality. Reach out to me, and let's start the conversation that could change the course of your brand's journey.</p>
-    <h3>📞 Give Me a Call</h3>
+    <h3>Give Me a Call</h3>
     <p class="about-paragraph">Ready for a chat? I'm all ears. Dial <a href="tel:3233568415">(323) 356-8415</a>, and let's talk about how we can create something extraordinary together.</p>
-    <h3>📧 Drop Me a Line</h3>
+    <h3>Drop Me a Line</h3>
     <p class="about-paragraph">Prefer to write? Send your thoughts, ideas, or inquiries to <a href="mailto:b@brandonwalowitz.com?subject=Let's Create Something Remarkable Together" target="_blank">b@brandonwalowitz.com</a>. I'm here to listen and bring your creative aspirations to life.</p>
     <p class="about-paragraph"> Remember, every great project starts with a simple conversation. Let's connect and explore the possibilities!</p>
 </div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <!-- Notice bar -->
 <div id="notice" style="display:none;background:#fff6d8;border-bottom:1px solid rgba(0,0,0,.1);font:15px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#2b2b2b;text-align:center">
   <div style="max-width:1200px;margin:0 auto;padding:10px 16px;display:flex;gap:12px;align-items:center;justify-content:center;flex-wrap:wrap">
-    <span>⚡ Site’s getting a refresh. Please excuse the mess while I update things.</span>
+    <span>Site’s getting a refresh. Please excuse the mess while I update things.</span>
     <button id="notice-close" aria-label="Dismiss" style="border:1px solid rgba(0,0,0,.15);background:#fff;border-radius:6px;padding:4px 10px;font-weight:600;cursor:pointer;font-size:14px">OK</button>
   </div>
 </div>

--- a/logistics.html
+++ b/logistics.html
@@ -95,17 +95,14 @@
       <!-- Value bullets -->
       <div class="grid gap-4 max-w-5xl mx-auto mb-12 center-grid md:grid-cols-3 md:place-items-stretch">
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl mb-2">📞</div>
           <h3 class="font-semibold mb-1">Prospecting and follow-up</h3>
           <p class="text-white/70 text-sm">Practice shipper calls and objection handling that mirrors your market.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl mb-2">💰</div>
           <h3 class="font-semibold mb-1">Rate strategy and margin discipline</h3>
           <p class="text-white/70 text-sm">Reps learn to quote with guardrails and defend value under price pressure.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl mb-2">✍️</div>
           <h3 class="font-semibold mb-1">Reusable copy blocks</h3>
           <p class="text-white/70 text-sm">Email and call snippets reps can reuse in outreach and follow-ups.</p>
         </div>
@@ -126,22 +123,18 @@
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-12 balance mx-auto h-measure leading-tight">How It Works</h2>
       <div class="grid gap-6 center-grid md:grid-cols-4 md:place-items-stretch">
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">📄</div>
           <h3 class="font-semibold mt-2">1. Upload scripts</h3>
           <p class="text-white/70 text-sm">Discovery, qualifying, value props, margin rules, and compliance notes.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🎛️</div>
           <h3 class="font-semibold mt-2">2. Select scenarios</h3>
           <p class="text-white/70 text-sm">Shipper personas, lane types, objections, accessorials, and detention cases.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🤖</div>
           <h3 class="font-semibold mt-2">3. Practice with AI</h3>
           <p class="text-white/70 text-sm">Reps role-play anytime. Immediate feedback. No calendar juggling.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">📈</div>
           <h3 class="font-semibold mt-2">4. Review and improve</h3>
           <p class="text-white/70 text-sm">See strengths, gaps, objection mastery, and next reps to coach.</p>
         </div>
@@ -155,17 +148,14 @@
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-12 balance mx-auto h-measure leading-tight">Why Teams Use This</h2>
       <div class="grid gap-6 center-grid md:grid-cols-3 md:place-items-stretch">
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">⚡</div>
           <h3 class="font-semibold mt-2">Faster ramp</h3>
           <p class="text-white/70 text-sm">New reps practice day one. Less shadowing. Less babysitting.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">🛡️</div>
           <h3 class="font-semibold mt-2">Consistent messaging</h3>
           <p class="text-white/70 text-sm">Your talk tracks, lanes, and brand voice in every simulation.</p>
         </div>
         <div class="card glass rounded-2xl p-6">
-          <div class="text-2xl">📊</div>
           <h3 class="font-semibold mt-2">Margin discipline</h3>
           <p class="text-white/70 text-sm">Guardrails keep quotes profitable while reps learn to defend value.</p>
         </div>
@@ -186,7 +176,7 @@
       <div class="grid gap-8 center-grid md:grid-cols-2 md:place-items-stretch">
         <!-- Brokerages & 3PLs -->
         <div class="card glass rounded-2xl p-6">
-          <div class="flex items-center gap-3 mb-4 text-lg"><span>🚚</span><span class="font-semibold">Brokerages & 3PLs</span></div>
+          <div class="mb-4 text-lg"><span class="font-semibold">Brokerages & 3PLs</span></div>
           <div class="grid md:grid-cols-2 gap-4">
             <div>
               <p class="text-xs uppercase tracking-wide text-white/60">The challenge</p>
@@ -200,7 +190,7 @@
         </div>
         <!-- Carriers -->
         <div class="card glass rounded-2xl p-6">
-          <div class="flex items-center gap-3 mb-4 text-lg"><span>🏗️</span><span class="font-semibold">Asset-based Carriers</span></div>
+          <div class="mb-4 text-lg"><span class="font-semibold">Asset-based Carriers</span></div>
           <div class="grid md:grid-cols-2 gap-4">
             <div>
               <p class="text-xs uppercase tracking-wide text-white/60">The challenge</p>


### PR DESCRIPTION
### Motivation
- Remove emoji characters and emoji-like glyphs from site HTML to keep headings and UI copy neutral and consistent across platforms. 
- The change targets notice banners, section headings, and small icon glyphs that were embedded as emoji characters on several pages. 

### Description
- Removed emoji characters from the homepage notice banner (`index.html`) and adjusted the span text to remain plain copy. 
- Removed emoji prefixes from contact headings in `contact.html` so section headings now read without emoji. 
- Stripped emoji glyphs from AI usage principle headings in `ai-usage.html`, including the `⏳` symbol for Principle 5, leaving the text intact. 
- Removed emoji icon elements/spans from `ai-sales-coach.html` and `logistics.html` while preserving the descriptive headings and body copy and cleaning up empty elements. 

### Testing
- Ran a Python regex scan across all `*.html` files to detect emoji characters in common emoji Unicode ranges, and the scan returned no matches (success). 
- Ran an expanded Python scan including emoji-like ranges and presentation selectors to ensure no emoji-like symbols remain (success). 
- Started a local static server with `python -m http.server` and captured a Playwright screenshot of `index.html` for a visual check, producing an artifact screenshot (success). 
- Performed a repository-wide search for emoji ranges with ripgrep and verified no remaining instances in the updated HTML files (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922086dd90832397ac0063f998faad)