### PR TITLE
Update footer copyright year to 2026 across site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/ai-sales-coach.html
+++ b/ai-sales-coach.html
@@ -269,8 +269,7 @@
   </section>
 
   <footer class="py-10 text-center text-white/50 text-sm">
-    © <span id="y"></span> Brandon Walowitz
-    <script>document.getElementById('y').textContent = new Date().getFullYear()</script>
+    © 2026 Brandon Walowitz
   </footer>
 
   <!-- Smooth scroll with easing and sticky-header offset -->

--- a/blog/index.html
+++ b/blog/index.html
@@ -23,7 +23,7 @@
 </ul>
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>
 </footer>
 </body>

--- a/blog/posts/2025-06-01-welcome.html
+++ b/blog/posts/2025-06-01-welcome.html
@@ -21,7 +21,7 @@
 <p class="main-paragraph">This is a short example post created to demonstrate the new blog section.</p>
 </main>
 <footer>
-    <p>COPYRIGHT ©2025 Brandon Walowitz</p>
+    <p>COPYRIGHT ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>
 </footer>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -41,7 +41,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/logistics.html
+++ b/logistics.html
@@ -246,8 +246,7 @@
   </section>
 
   <footer class="py-10 text-center text-white/50 text-sm">
-    © <span id="y"></span> Brandon Walowitz
-    <script>document.getElementById('y').textContent = new Date().getFullYear()</script>
+    © 2026 Brandon Walowitz
   </footer>
 
   <!-- Smooth scroll with easing and sticky-header offset -->

--- a/project-1.html
+++ b/project-1.html
@@ -27,7 +27,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/project-abled.html
+++ b/project-abled.html
@@ -46,7 +46,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/project-c2c.html
+++ b/project-c2c.html
@@ -36,7 +36,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/project-makeful.html
+++ b/project-makeful.html
@@ -40,7 +40,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/project-mrkate.html
+++ b/project-mrkate.html
@@ -42,7 +42,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/project-sarahsilverman.html
+++ b/project-sarahsilverman.html
@@ -41,7 +41,7 @@
 
 </main>
 <footer>
-    <p>Copyright ©2025 Brandon Walowitz</p>
+    <p>Copyright ©2026 Brandon Walowitz</p>
     <p>All Rights Reserved</p>  
 </footer>
 </body>

--- a/resume.html
+++ b/resume.html
@@ -253,7 +253,7 @@
         <a href="https://www.linkedin.com/in/brandonwalowitz/" target="_blank" rel="noopener">LinkedIn</a>
         <a href="mailto:b@brandonwalowitz.com">Email</a>
       </div>
-      <p style="margin:10px 0 0">© <span id="y"></span> Brandon Walowitz</p>
+      <p style="margin:10px 0 0">© 2026 Brandon Walowitz</p>
     </div>
   </div>
 
@@ -266,7 +266,6 @@
         if(el){ window.scrollTo({top: el.getBoundingClientRect().top + window.pageYOffset - 8, behavior:'smooth'}); }
       });
     });
-    document.getElementById('y').textContent = new Date().getFullYear();
   </script>
 
   <script type="application/ld+json">


### PR DESCRIPTION
### Motivation
- Ensure the public site consistently displays the requested copyright year of 2026 across all pages.
- Remove inconsistent dynamic year rendering in favor of the fixed year requested so the footer matches on all static pages.

### Description
- Replaced `Copyright ©2025` with `Copyright ©2026` across core pages, project pages, and blog pages (examples: `index.html`, `about.html`, `contact.html`, `project-*.html`, `blog/index.html`, `blog/posts/2025-06-01-welcome.html`).
- Replaced instances of `© <span id="y"></span>` plus the JavaScript year assignment with the fixed text `© 2026 Brandon Walowitz` in `ai-sales-coach.html` and `logistics.html`.
- Updated the footer in `resume.html` to `© 2026 Brandon Walowitz` and removed the `document.getElementById('y').textContent = new Date().getFullYear()` line.
- Applied the same text-case COPYRIGHT change in `blog/posts/2025-06-01-welcome.html` so the post footer now reads `COPYRIGHT ©2026 Brandon Walowitz`.

### Testing
- Ran a targeted search with `rg` to find and confirm all occurrences of `2026` in `*.html`, `blog/*.html`, and `blog/posts/*.html`, and the search returned expected matches.
- Ran the inplace replacement script (`python` one-liner) to perform the updates and printed modified file paths for verification.
- Started a local server with `python -m http.server 8000` and captured a Playwright screenshot of `http://127.0.0.1:8000/index.html` to visually confirm the updated footer.
- Re-ran `rg` to ensure no `2025` footer occurrences remained and all pages now include `2026`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699221c458a08323a1d6d758f9c618ff)