### PR TITLE
Add `freight.html` - Freight Pilot product spec page

### DIFF
--- a/freight.html
+++ b/freight.html
@@ -1,0 +1,847 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Freight Pilot · Product Spec</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=Space+Mono:wght@400;700&display=swap"
+    rel="stylesheet"
+  />
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html, body {
+      background: #0a0a0a;
+      color: #e5e7eb;
+      font-family: "Syne", sans-serif;
+      min-height: 100%;
+    }
+
+    body {
+      line-height: 1.5;
+    }
+
+    ::-webkit-scrollbar {
+      width: 4px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: #0a0a0a;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: #f97316;
+      border-radius: 2px;
+    }
+
+    .page {
+      min-height: 100vh;
+      background: #0a0a0a;
+      color: #e5e7eb;
+    }
+
+    .header {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+      padding: 2rem 2.5rem 1.5rem;
+      position: sticky;
+      top: 0;
+      background: #0a0a0a;
+      z-index: 10;
+    }
+
+    .header-inner {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 1rem;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+
+    .eyebrow {
+      font-size: 0.6rem;
+      font-family: "Space Mono", monospace;
+      letter-spacing: 0.25em;
+      color: #f97316;
+      margin-bottom: 0.4rem;
+      text-transform: uppercase;
+    }
+
+    .title {
+      font-size: 2rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1;
+    }
+
+    .subtitle {
+      color: #9ca3af;
+      font-size: 0.85rem;
+      margin-top: 0.4rem;
+    }
+
+    .tab-buttons {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .tab-button {
+      background: transparent;
+      color: #9ca3af;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+      padding: 0.4rem 1rem;
+      font-size: 0.72rem;
+      font-family: "Space Mono", monospace;
+      cursor: pointer;
+      letter-spacing: 0.05em;
+      transition: all 0.2s ease;
+    }
+
+    .tab-button.active {
+      background: #f97316;
+      color: #000;
+      border-color: #f97316;
+    }
+
+    .content {
+      padding: 2.5rem;
+      max-width: 850px;
+      margin: 0 auto;
+    }
+
+    .section {
+      margin-bottom: 2.5rem;
+    }
+
+    .section-label {
+      font-size: 0.65rem;
+      font-family: "Space Mono", monospace;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: #f97316;
+      margin-bottom: 0.75rem;
+      border-left: 2px solid #f97316;
+      padding-left: 0.75rem;
+    }
+
+    .body-copy {
+      color: #d1d5db;
+      line-height: 1.8;
+      font-size: 0.92rem;
+    }
+
+    .body-copy strong {
+      color: #e5e7eb;
+    }
+
+    .muted-copy {
+      color: #9ca3af;
+      font-size: 0.85rem;
+      line-height: 1.7;
+    }
+
+    .tags {
+      margin-bottom: 0.75rem;
+    }
+
+    .tag {
+      display: inline-block;
+      background: rgba(249, 115, 22, 0.12);
+      color: #f97316;
+      border: 1px solid rgba(249, 115, 22, 0.3);
+      border-radius: 3px;
+      padding: 0.2rem 0.6rem;
+      font-size: 0.72rem;
+      font-family: "Space Mono", monospace;
+      margin-right: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .agent-step {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1.2rem;
+      align-items: flex-start;
+    }
+
+    .agent-step-num {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: rgba(249, 115, 22, 0.15);
+      border: 1px solid rgba(249, 115, 22, 0.4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      font-family: "Space Mono", monospace;
+      color: #f97316;
+      flex-shrink: 0;
+    }
+
+    .agent-step-title {
+      color: #e5e7eb;
+      font-size: 0.88rem;
+      font-weight: 600;
+      margin-bottom: 0.2rem;
+    }
+
+    .agent-step-detail {
+      color: #9ca3af;
+      font-size: 0.8rem;
+      line-height: 1.6;
+    }
+
+    .row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1rem;
+      padding: 0.6rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .row-label {
+      color: #6b7280;
+      font-size: 0.82rem;
+      font-family: "Space Mono", monospace;
+      min-width: 140px;
+    }
+
+    .row-value {
+      color: #e5e7eb;
+      font-size: 0.85rem;
+      text-align: right;
+      max-width: 280px;
+      line-height: 1.5;
+    }
+
+    .small-note {
+      margin-top: 1rem;
+      color: #6b7280;
+      font-size: 0.78rem;
+      line-height: 1.7;
+    }
+
+    .comparison-row {
+      display: grid;
+      grid-template-columns: 1fr 2fr;
+      gap: 1rem;
+      padding: 0.75rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      font-size: 0.83rem;
+    }
+
+    .comparison-left {
+      color: #f97316;
+      font-family: "Space Mono", monospace;
+      font-size: 0.75rem;
+    }
+
+    .comparison-right {
+      color: #d1d5db;
+      line-height: 1.6;
+    }
+
+    .question-row {
+      display: flex;
+      gap: 0.75rem;
+      padding: 0.6rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      font-size: 0.83rem;
+      color: #9ca3af;
+      align-items: flex-start;
+    }
+
+    .question-mark {
+      color: #f97316;
+      font-family: "Space Mono", monospace;
+      font-size: 0.7rem;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    .mvp-copy {
+      color: #d1d5db;
+      font-size: 0.85rem;
+      line-height: 1.8;
+      margin-bottom: 1rem;
+    }
+
+    .mvp-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.5rem;
+    }
+
+    .mvp-item {
+      background: rgba(255, 255, 255, 0.02);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 4px;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.75rem;
+      font-family: "Space Mono", monospace;
+      color: #d1d5db;
+    }
+
+    .sample-intro {
+      color: #9ca3af;
+      font-size: 0.82rem;
+      margin-bottom: 1.5rem;
+      line-height: 1.6;
+    }
+
+    .sample-intro em {
+      color: #d1d5db;
+      font-style: italic;
+    }
+
+    .prospect-card {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(249, 115, 22, 0.2);
+      border-radius: 8px;
+      padding: 1.25rem;
+      font-family: "Space Mono", monospace;
+      font-size: 0.75rem;
+    }
+
+    .prospect-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1rem;
+      align-items: flex-start;
+    }
+
+    .prospect-label {
+      color: #f97316;
+      font-size: 0.65rem;
+      letter-spacing: 0.1em;
+      margin-bottom: 0.25rem;
+    }
+
+    .prospect-company {
+      color: #e5e7eb;
+      font-size: 1rem;
+      font-weight: 700;
+      font-family: "Syne", sans-serif;
+    }
+
+    .prospect-meta {
+      color: #9ca3af;
+      font-size: 0.75rem;
+      margin-top: 0.15rem;
+    }
+
+    .fit-badge {
+      background: rgba(34, 197, 94, 0.1);
+      border: 1px solid rgba(34, 197, 94, 0.3);
+      color: #22c55e;
+      border-radius: 4px;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.65rem;
+      height: fit-content;
+      white-space: nowrap;
+    }
+
+    .prospect-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .prospect-field-label {
+      color: #6b7280;
+      font-size: 0.62rem;
+      margin-bottom: 0.15rem;
+    }
+
+    .prospect-field-value {
+      color: #e5e7eb;
+    }
+
+    .prospect-block {
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+      padding-top: 0.85rem;
+    }
+
+    .prospect-block + .prospect-block {
+      margin-top: 0.85rem;
+    }
+
+    .prospect-block-label {
+      color: #6b7280;
+      font-size: 0.62rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .prospect-block-copy {
+      color: #d1d5db;
+      line-height: 1.7;
+      font-size: 0.75rem;
+    }
+
+    .prospect-block-copy.italic {
+      font-style: italic;
+    }
+
+    .sample-note {
+      color: #6b7280;
+      font-size: 0.75rem;
+      margin-top: 1rem;
+      font-family: "Space Mono", monospace;
+    }
+
+    .replacement-row {
+      display: grid;
+      grid-template-columns: 2fr 80px 2fr;
+      gap: 0.75rem;
+      padding: 0.65rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      align-items: center;
+      font-size: 0.8rem;
+    }
+
+    .replacement-task {
+      color: #9ca3af;
+      text-decoration: line-through;
+    }
+
+    .replacement-time {
+      color: #ef4444;
+      font-family: "Space Mono", monospace;
+      font-size: 0.72rem;
+    }
+
+    .replacement-result {
+      color: #22c55e;
+      font-size: 0.75rem;
+    }
+
+    .time-saved {
+      margin-top: 1.25rem;
+      padding: 1rem;
+      background: rgba(249, 115, 22, 0.06);
+      border: 1px solid rgba(249, 115, 22, 0.2);
+      border-radius: 6px;
+      font-size: 0.82rem;
+      color: #d1d5db;
+      line-height: 1.7;
+    }
+
+    .time-saved strong {
+      color: #f97316;
+    }
+
+    .footer {
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+      padding-top: 1.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .footer-note {
+      color: #4b5563;
+      font-size: 0.7rem;
+      font-family: "Space Mono", monospace;
+    }
+
+    .tab-panel {
+      display: none;
+    }
+
+    .tab-panel.active {
+      display: block;
+    }
+
+    @media (max-width: 768px) {
+      .header,
+      .content {
+        padding-left: 1.25rem;
+        padding-right: 1.25rem;
+      }
+
+      .title {
+        font-size: 1.6rem;
+      }
+
+      .row {
+        flex-direction: column;
+      }
+
+      .row-value {
+        text-align: left;
+        max-width: 100%;
+      }
+
+      .comparison-row,
+      .replacement-row,
+      .mvp-grid,
+      .prospect-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .prospect-top {
+        flex-direction: column;
+      }
+
+      .footer {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="header">
+      <div class="header-inner">
+        <div>
+          <div class="eyebrow">PRODUCT SPEC · DRAFT 1 · APRIL 2026</div>
+          <div class="title">FREIGHT PILOT</div>
+          <div class="subtitle">AI prospect agent for logistics salespeople</div>
+        </div>
+
+        <div class="tab-buttons">
+          <button class="tab-button active" data-tab="spec">PRODUCT SPEC</button>
+          <button class="tab-button" data-tab="sample">SAMPLE OUTPUT</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="content">
+      <div id="spec" class="tab-panel active">
+        <div class="section">
+          <div class="section-label">The Problem</div>
+          <p class="body-copy">
+            A logistics salesperson spends the first 2–3 hours of their day doing things that aren't sales: searching ZoomInfo, verifying contacts, researching companies, writing outreach. By the time they make a call, they've already spent their sharpest hours on admin. <strong>Freight Pilot gives that time back.</strong>
+          </p>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Target Customer</div>
+          <div class="tags">
+            <span class="tag">Small-to-mid freight brokerages</span>
+            <span class="tag">2–15 salespeople</span>
+            <span class="tag">Commission-based</span>
+            <span class="tag">No enterprise tooling</span>
+          </div>
+          <p class="muted-copy">
+            Individual salespeople who pay out of pocket for an edge. Not the IT department. Not the VP of Sales. The rep on quota who wants more dials with less prep.
+          </p>
+        </div>
+
+        <div class="section">
+          <div class="section-label">What the Agent Does</div>
+
+          <div class="agent-step">
+            <div class="agent-step-num">1</div>
+            <div>
+              <div class="agent-step-title">You describe what you need</div>
+              <div class="agent-step-detail">
+                Natural language. “Give me 10 food &amp; beverage manufacturers in the southeast, looking for a transportation manager or logistics director, who might be shopping for a new TL provider.”
+              </div>
+            </div>
+          </div>
+
+          <div class="agent-step">
+            <div class="agent-step-num">2</div>
+            <div>
+              <div class="agent-step-title">Agent searches and enriches</div>
+              <div class="agent-step-detail">
+                Pulls company data, verifies the right contact title, finds email + phone, checks LinkedIn activity, scans for intent signals like job postings, news, capacity complaints, and new warehouse openings.
+              </div>
+            </div>
+          </div>
+
+          <div class="agent-step">
+            <div class="agent-step-num">3</div>
+            <div>
+              <div class="agent-step-title">Agent researches the person</div>
+              <div class="agent-step-detail">
+                Recent LinkedIn posts, shared interests, tenure, anything that creates a real conversation hook, not just a first name in a template.
+              </div>
+            </div>
+          </div>
+
+          <div class="agent-step">
+            <div class="agent-step-num">4</div>
+            <div>
+              <div class="agent-step-title">Agent writes the opener</div>
+              <div class="agent-step-detail">
+                One personalized first-contact email or LinkedIn message based on the intel gathered. Not a template, specific to this person, this company, this moment.
+              </div>
+            </div>
+          </div>
+
+          <div class="agent-step">
+            <div class="agent-step-num">5</div>
+            <div>
+              <div class="agent-step-title">You receive a Prospect Card</div>
+              <div class="agent-step-detail">
+                Everything above, formatted cleanly. Name, title, verified contact info, intel brief, suggested opener. Ready to call or send.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">What It Is Not</div>
+          <p class="muted-copy">
+            Not a directory. Not a CRM. Not another ZoomInfo clone. Those tools hand you a list, you still do all the work. Freight Pilot does the work and hands you a person who's ready to contact, with context, a reason to call, and something to say.
+          </p>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Business Model</div>
+          <div class="row">
+            <span class="row-label">Model</span>
+            <span class="row-value">Pay-per-prospect (credits)</span>
+          </div>
+          <div class="row">
+            <span class="row-label">Starting price</span>
+            <span class="row-value">$5 / prospect card</span>
+          </div>
+          <div class="row">
+            <span class="row-label">Volume tiers</span>
+            <span class="row-value">$4 at 50+/mo · $3 at 200+/mo</span>
+          </div>
+          <div class="row">
+            <span class="row-label">Entry point</span>
+            <span class="row-value">Free trial: 5 cards, no credit card</span>
+          </div>
+          <div class="row">
+            <span class="row-label">Future</span>
+            <span class="row-value">Team subscriptions for small brokerages</span>
+          </div>
+
+          <div class="small-note">
+            If one converted prospect earns a rep $2,000–$10,000 in commission, a $5 card that helped land it is a 400x–2000x return. The price is never the objection, quality and trust are.
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Why This vs. ZoomInfo / Seamless AI</div>
+
+          <div class="comparison-row">
+            <span class="comparison-left">They sell data.</span>
+            <span class="comparison-right">We sell a ready-to-contact prospect. The research, the intel, and the opener are included.</span>
+          </div>
+
+          <div class="comparison-row">
+            <span class="comparison-left">They need training.</span>
+            <span class="comparison-right">You talk to this like a person. No filters, no Boolean, no learning curve.</span>
+          </div>
+
+          <div class="comparison-row">
+            <span class="comparison-left">They're expensive.</span>
+            <span class="comparison-right">$15k–$20k/yr for enterprise seats. We're $5 per card, no commitment.</span>
+          </div>
+
+          <div class="comparison-row">
+            <span class="comparison-left">They go stale.</span>
+            <span class="comparison-right">Agent checks signals at the moment you ask, not from a database last updated 6 months ago.</span>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Open Questions (To Validate)</div>
+
+          <div class="question-row">
+            <span class="question-mark">?</span>
+            <span>Will individual salespeople pay out of pocket, or do they need employer buy-in?</span>
+          </div>
+
+          <div class="question-row">
+            <span class="question-mark">?</span>
+            <span>What's the minimum trust bar, how do they know the contact info is real?</span>
+          </div>
+
+          <div class="question-row">
+            <span class="question-mark">?</span>
+            <span>Email delivery or dashboard? How do they want to receive cards?</span>
+          </div>
+
+          <div class="question-row">
+            <span class="question-mark">?</span>
+            <span>Is the personalized opener a feature or a nice-to-have?</span>
+          </div>
+
+          <div class="question-row">
+            <span class="question-mark">?</span>
+            <span>What verticals matter most? Food &amp; bev, retail, medical, manufacturing?</span>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">MVP — What Gets Built First</div>
+          <p class="mvp-copy">
+            A single-purpose web app. User describes the type of prospect they want. Agent returns 1–10 prospect cards. User can purchase more credits. That's it. No dashboard, no CRM sync, no team features, until it's proven.
+          </p>
+
+          <div class="mvp-grid">
+            <div class="mvp-item">✓ Natural language input</div>
+            <div class="mvp-item">✓ Web search + enrichment</div>
+            <div class="mvp-item">✓ Prospect card output</div>
+            <div class="mvp-item">✓ Personalized opener draft</div>
+            <div class="mvp-item">✓ Credit-based billing</div>
+            <div class="mvp-item">✗ CRM integration (v2)</div>
+            <div class="mvp-item">✗ Email sending (v2)</div>
+            <div class="mvp-item">✗ Team accounts (v2)</div>
+          </div>
+        </div>
+      </div>
+
+      <div id="sample" class="tab-panel">
+        <div class="section">
+          <div class="section-label">Sample Prospect Card Output</div>
+          <p class="sample-intro">
+            This is what a user receives after asking:
+            <em>“Find me a food manufacturer in the southeast with a transportation manager who might be shopping for a new TL provider.”</em>
+          </p>
+
+          <div class="prospect-card">
+            <div class="prospect-top">
+              <div>
+                <div class="prospect-label">PROSPECT CARD</div>
+                <div class="prospect-company">Hartline Foods Inc.</div>
+                <div class="prospect-meta">Food &amp; Beverage Manufacturer · Memphis, TN</div>
+              </div>
+              <div class="fit-badge">HIGH FIT</div>
+            </div>
+
+            <div class="prospect-grid">
+              <div>
+                <div class="prospect-field-label">Contact</div>
+                <div class="prospect-field-value">James Pruitt</div>
+              </div>
+              <div>
+                <div class="prospect-field-label">Title</div>
+                <div class="prospect-field-value">Dir. of Transportation</div>
+              </div>
+              <div>
+                <div class="prospect-field-label">Email</div>
+                <div class="prospect-field-value">j.pruitt@hartlinefoods.com</div>
+              </div>
+              <div>
+                <div class="prospect-field-label">Phone</div>
+                <div class="prospect-field-value">(901) 555-0182</div>
+              </div>
+              <div>
+                <div class="prospect-field-label">Est. Freight Spend</div>
+                <div class="prospect-field-value">$2.1M / yr</div>
+              </div>
+              <div>
+                <div class="prospect-field-label">Lanes</div>
+                <div class="prospect-field-value">SE + Midwest heavy</div>
+              </div>
+            </div>
+
+            <div class="prospect-block">
+              <div class="prospect-block-label">INTEL</div>
+              <div class="prospect-block-copy">
+                Recently lost preferred carrier due to capacity issues in Q1. Actively searching for new TL providers per ZoomInfo intent signal. James posted on LinkedIn 3 weeks ago about “carrier reliability being the #1 issue this year.” Company added 2 new DCs in Q4, freight volume likely up 15–20%.
+              </div>
+            </div>
+
+            <div class="prospect-block">
+              <div class="prospect-block-label">SUGGESTED OPENER</div>
+              <div class="prospect-block-copy italic">
+                “James, Derek with [Brokerage]. Noticed you've been expanding your DC footprint in the southeast. With capacity tightening on that corridor, I wanted to reach out before your next bid cycle. Worth a 15-minute call?”
+              </div>
+            </div>
+          </div>
+
+          <p class="sample-note">
+            * Sample data — illustrative only. Real cards would use live-verified data.
+          </p>
+        </div>
+
+        <div class="section">
+          <div class="section-label">What This Replaces</div>
+
+          <div class="replacement-row">
+            <span class="replacement-task">ZoomInfo search + filter</span>
+            <span class="replacement-time">~25 min</span>
+            <span class="replacement-result">Included in card generation</span>
+          </div>
+
+          <div class="replacement-row">
+            <span class="replacement-task">LinkedIn verification</span>
+            <span class="replacement-time">~10 min</span>
+            <span class="replacement-result">Included in card generation</span>
+          </div>
+
+          <div class="replacement-row">
+            <span class="replacement-task">Company intel research</span>
+            <span class="replacement-time">~20 min</span>
+            <span class="replacement-result">Included in card generation</span>
+          </div>
+
+          <div class="replacement-row">
+            <span class="replacement-task">Writing the opener</span>
+            <span class="replacement-time">~10 min</span>
+            <span class="replacement-result">Included in card generation</span>
+          </div>
+
+          <div class="time-saved">
+            <strong>~65 minutes of prep work</strong> reduced to the time it takes to read the card and pick up the phone.
+          </div>
+        </div>
+      </div>
+
+      <div class="footer">
+        <span class="footer-note">FREIGHT PILOT · SPEC v0.1 · BRANDON WALOWITZ</span>
+        <span class="footer-note">APRIL 2026 · CONFIDENTIAL</span>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const buttons = document.querySelectorAll(".tab-button");
+    const panels = document.querySelectorAll(".tab-panel");
+
+    function setActiveTab(target, updateHash = false) {
+      if (!target || !document.getElementById(target)) return;
+
+      buttons.forEach((b) => {
+        const isTarget = b.getAttribute("data-tab") === target;
+        b.classList.toggle("active", isTarget);
+      });
+
+      panels.forEach((p) => {
+        p.classList.toggle("active", p.id === target);
+      });
+
+      if (updateHash) {
+        history.replaceState(null, "", `#${target}`);
+      }
+    }
+
+    const initialTab = window.location.hash.replace("#", "");
+    if (initialTab === "spec" || initialTab === "sample") {
+      setActiveTab(initialTab);
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.getAttribute("data-tab");
+        setActiveTab(target, true);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a standalone, shareable product spec for the Freight Pilot concept to document the problem, target customer, MVP, business model, and sample output. 
- Provide a lightweight, static HTML page that designers, PMs, and stakeholders can open in a browser without requiring a build step. 
- Capture a polished example prospect card and UX details to guide implementation and user research.

### Description
- Add a new file `freight.html` containing the full product spec markup, inline styles, and a small script to switch between the "PRODUCT SPEC" and "SAMPLE OUTPUT" tabs. 
- Implement responsive layout and visual styling (Google fonts, dark theme, responsive grid, sticky header, and custom scrollbar) entirely via inline CSS. 
- Include content sections covering problem, target customer, agent workflow, business model, comparisons, open questions, MVP checklist, a sample prospect card, and time-saved comparisons. 
- Provide a minimal JS tab handler that updates the URL hash and toggles `.active` classes on tab buttons and panels.

### Testing
- No automated tests were run for this static HTML asset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad5b1ae788323aafe62f5247c8528)