### PR TITLE
[codex] Restore visible portfolio videos

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/art-and-science.html
+++ b/art-and-science.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/broadcast-package.html
+++ b/broadcast-package.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/coast-to-coast.html
+++ b/coast-to-coast.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/lightifier.html
+++ b/lightifier.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/makeful.html
+++ b/makeful.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/outstanding.html
+++ b/outstanding.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/project.html
+++ b/project.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/projects-data.js
+++ b/projects-data.js
@@ -217,13 +217,12 @@ const PROJECTS = [
     ],
     details:[["Project","Voices of Learning"],["Period","Archived work"],["Scope","Educational Video Series"],["Role","Video Producer"]],
     shots:[
-      {image:"images/sarahsilverman-1.png",wide:true,fit:"contain",background:"#111111",aspect:"16/9"},
-      {video:"7O56hYuq7w4",wide:true},
-      {video:"feD2OYZnzfw",wide:true},
-      {video:"62bJxibZ0B0",wide:true},
-      {video:"OqEGHXBvXlE",wide:true},
-      {video:"D4e8vT-HnpY",wide:true},
-      {video:"72dRZcbm-8U",wide:true}
+      {video:"7O56hYuq7w4",title:"Sarah Silverman's Voices of Learning: Episode 1",wide:true},
+      {video:"feD2OYZnzfw",title:"Sarah Silverman's Voices of Learning: Episode 2",wide:true},
+      {video:"62bJxibZ0B0",title:"Sarah Silverman's Voices of Learning: Episode 3",wide:true},
+      {video:"OqEGHXBvXlE",title:"Sarah Silverman's Voices of Learning: Episode 4",wide:true},
+      {video:"D4e8vT-HnpY",title:"Sarah Silverman's Voices of Learning: Episode 5",wide:true},
+      {video:"72dRZcbm-8U",title:"Sarah Silverman's Voices of Learning: Episode 6",wide:true}
     ]
   },
   {
@@ -261,13 +260,12 @@ const PROJECTS = [
     ],
     details:[["Client","Makeful"],["Period","Archived work"],["Scope","Programming · Writing · Video"],["Role","Director of Programming · Writer"]],
     shots:[
-      {image:"images/makeful-1.png",wide:true,fit:"contain",background:"#efe8e1",aspect:"16/9"},
-      {video:"UrrY814gYQk",wide:true},
-      {video:"ZaoSsVsl6YE",wide:true},
-      {video:"yvL2hjvBbbA",wide:true},
-      {video:"1peZkwhqj3o",wide:true},
-      {video:"bC7xP1wmVro",wide:true},
-      {video:"hMumsDg0lP4",wide:true}
+      {video:"UrrY814gYQk",title:"DIY Pom Pom Lamp Shade | 3 Minute DIY with Jeanine Amapola",wide:true},
+      {video:"ZaoSsVsl6YE",title:"Mason Jar Candle Holders | 3 Minute DIY with Jeanine Amapola",wide:true},
+      {video:"yvL2hjvBbbA",title:"Easy Travel Tips & Hacks | Girl, Get Your Life! | Makeful",wide:true},
+      {video:"1peZkwhqj3o",title:"3 Easy Cake Decorating Hacks with Cutlery",wide:true},
+      {video:"bC7xP1wmVro",title:"Try These Easy Fruit-Cutting Hacks!",wide:true},
+      {video:"hMumsDg0lP4",title:"Learning To Paint | The Creative Lab | Makeful",wide:true}
     ]
   },
   {
@@ -286,15 +284,14 @@ const PROJECTS = [
     ],
     details:[["Client","Mr. Kate"],["Period","Archived work"],["Scope","Lifestyle Video Series"],["Role","Video Producer"]],
     shots:[
-      {image:"images/mrkate-1.png",wide:true,fit:"contain",background:"#111111",aspect:"16/9"},
-      {video:"7BcNeFmdkQw",wide:true},
-      {video:"R5P5N7jlPFg",wide:true},
-      {video:"EDZrHpKpmCs",wide:true},
-      {video:"PV_GHHXy7Po",wide:true},
-      {video:"rsSCMAPD0Fg",wide:true},
-      {video:"A8u1jqvDsVY",wide:true},
-      {video:"o_az8-Kyd88",wide:true},
-      {video:"cfLV2KDhxQQ",wide:true}
+      {video:"7BcNeFmdkQw",title:"Liza Koshy's Urban Outdoor Oasis Makeover! | OMG We're Coming Over",wide:true},
+      {video:"R5P5N7jlPFg",title:"Design Vs. Design — Room Makeover Competition!",wide:true},
+      {video:"EDZrHpKpmCs",title:"Colleen Ballinger's Nursery Makeover!",wide:true},
+      {video:"PV_GHHXy7Po",title:"Joey Graceffa's Enchanted Gaming Room Makeover! | OMG We're Coming Over",wide:true},
+      {video:"rsSCMAPD0Fg",title:"Interior Design For A Blind Person? Ft. Molly Burke x OMG We’re Coming Over",wide:true},
+      {video:"A8u1jqvDsVY",title:"Surprise Brother and Sister Room Makeovers! | Mr. Kate Decorates",wide:true},
+      {video:"o_az8-Kyd88",title:"Tween Bedroom on a Budget *emotional* | Mr. Kate Decorates",wide:true},
+      {video:"cfLV2KDhxQQ",title:"Dolan Twins House Makeover! | OMG We're Coming Over",wide:true}
     ]
   },
   {

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/short-film.html
+++ b/short-film.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -74,6 +74,9 @@
   .case-kicker{font-family:var(--mono);font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:26px;}
   .case-hero h1{font-family:var(--serif);font-weight:300;font-size:clamp(44px,8.5vw,128px);line-height:0.94;letter-spacing:-0.02em;max-width:14ch;}
   .case-intro{margin-top:34px;max-width:58ch;font-size:clamp(17px,1.7vw,24px);line-height:1.5;color:var(--ink-dim);}
+  .media-jump{display:inline-flex;align-items:center;gap:10px;margin-top:24px;font-family:var(--mono);font-size:11px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--ink);border-bottom:1px solid var(--line);padding-bottom:6px;transition:border-color .3s;}
+  .media-jump:hover{border-color:var(--ink);}
 
   .case-cover{height:clamp(280px,54vh,640px);border-radius:6px;margin:clamp(44px,7vh,90px) clamp(20px,5vw,64px);
     background-size:cover;background-position:center;position:relative;overflow:hidden;box-shadow:0 50px 110px -50px rgba(0,0,0,0.9);}
@@ -95,7 +98,11 @@
   .case-cta:hover{background:var(--ink);color:var(--bg);border-color:var(--ink);}
   @media(max-width:860px){.case-grid{grid-template-columns:1fr;gap:48px;}}
 
-  .case-shots{padding-bottom:clamp(80px,12vh,140px);}
+  .case-shots{padding-bottom:clamp(80px,12vh,140px);scroll-margin-top:110px;}
+  .media-heading{display:flex;justify-content:space-between;align-items:end;gap:24px;}
+  .media-heading h2{font-family:var(--serif);font-weight:300;font-size:clamp(34px,5vw,72px);line-height:1;letter-spacing:-.02em;}
+  .media-heading .label{margin-bottom:8px;}
+  .media-count{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;white-space:nowrap;}
   .shots-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(16px,2vw,28px);margin-top:36px;}
   .shot{aspect-ratio:4/3;border-radius:5px;background-size:cover;background-position:center;background-repeat:no-repeat;position:relative;overflow:hidden;
     box-shadow:0 30px 60px -34px rgba(0,0,0,0.8);}
@@ -103,10 +110,23 @@
   .shot.video{aspect-ratio:16/9;background:#000;}
   .shot.video::before{display:none;}
   .shot iframe{position:absolute;inset:0;width:100%;height:100%;border:0;z-index:1;}
+  .video-card{min-width:0;}
+  .video-card.wide{grid-column:1/-1;}
+  .video-card .shot{width:100%;aspect-ratio:16/9;}
+  .video-meta{display:flex;justify-content:space-between;align-items:start;gap:24px;padding:15px 2px 5px;}
+  .video-title{font-size:clamp(15px,1.4vw,18px);line-height:1.35;color:var(--ink);}
+  .video-link{flex:0 0 auto;font-family:var(--mono);font-size:10px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-dim);
+    border-bottom:1px solid var(--line);padding-bottom:4px;transition:color .3s,border-color .3s;}
+  .video-link:hover{color:var(--ink);border-color:var(--ink);}
   .shot::before{content:"";position:absolute;inset:0;opacity:.4;mix-blend-mode:overlay;
     background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");}
   .shot .fl{position:absolute;left:16px;bottom:13px;z-index:2;pointer-events:none;font-family:var(--mono);font-size:10px;letter-spacing:.16em;color:rgba(243,239,230,0.6);}
-  @media(max-width:640px){.shots-grid{grid-template-columns:1fr;}}
+  @media(max-width:640px){
+    .media-heading{align-items:start;flex-direction:column;gap:12px;}
+    .shots-grid{grid-template-columns:1fr;}
+    .video-meta{display:block;}
+    .video-link{display:inline-block;margin-top:10px;}
+  }
 
   .case-next{border-top:1px solid var(--line);margin-top:clamp(20px,4vh,40px);padding:clamp(60px,10vh,120px) 0;}
   .next-link{display:block;}
@@ -182,20 +202,33 @@ function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','
 
 function shotTiles(p){
   if(p.shots && p.shots.length){
+    let videoIndex=0;
+    let frameIndex=0;
     return p.shots.map((s,i)=>{
       const aspect = s.aspect ? `aspect-ratio:${s.aspect};` : '';
       if(s.video){
-        return `<div class="shot video ${s.wide?'wide':''}" style="${aspect}">
-          <iframe loading="lazy" src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}"
-            title="${esc(p.title)} video ${i+1}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-          <span class="fl">VIDEO ${String(i+1).padStart(2,'0')}</span></div>`;
+        videoIndex+=1;
+        const title=s.title||`${p.title} video ${videoIndex}`;
+        const youtubeUrl=`https://www.youtube.com/watch?v=${encodeURIComponent(s.video)}`;
+        return `<article class="video-card ${s.wide?'wide':''}">
+          <div class="shot video" style="${aspect}">
+            <iframe src="https://www.youtube-nocookie.com/embed/${encodeURIComponent(s.video)}?rel=0"
+              title="${esc(title)}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <span class="fl">VIDEO ${String(videoIndex).padStart(2,'0')}</span>
+          </div>
+          <div class="video-meta">
+            <p class="video-title">${esc(title)}</p>
+            <a class="video-link" href="${youtubeUrl}" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
+          </div>
+        </article>`;
       }
+      frameIndex+=1;
       const bg = s.image ? `background-image:url('${s.image}')` : `background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})`;
       const fit = s.fit ? `background-size:${s.fit};` : '';
       const position = s.position ? `background-position:${s.position};` : '';
       const background = s.background ? `background-color:${s.background};` : '';
-      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(i+1).padStart(2,'0')}</span></div>`;
+      return `<div class="shot ${s.wide?'wide':''}" style="${bg};${fit}${position}${background}${aspect}"><span class="fl">FRAME ${String(frameIndex).padStart(2,'0')}</span></div>`;
     }).join('');
   }
   const [a,b]=p.accent;
@@ -219,6 +252,16 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const videoCount = (p.shots||[]).filter(s=>s.video).length;
+  const imageCount = (p.shots||[]).filter(s=>!s.video).length;
+  const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
+  const mediaCount = [
+    imageCount ? `${imageCount} ${imageCount===1?'frame':'frames'}` : '',
+    videoCount ? `${videoCount} ${videoCount===1?'video':'videos'}` : ''
+  ].filter(Boolean).join(' · ');
+  const mediaJump = videoCount
+    ? `<a class="media-jump" href="#project-media" data-cursor>Watch all ${videoCount} videos ↓</a>`
+    : '';
 
   main.innerHTML=`
     <header class="case-hero">
@@ -227,6 +270,7 @@ function render(p){
         <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
+        ${mediaJump}
       </div>
     </header>
 
@@ -242,8 +286,14 @@ function render(p){
       </div>
     </section>
 
-    <section class="case-shots reveal">
-      <p class="label">Selected frames</p>
+    <section class="case-shots" id="project-media">
+      <div class="media-heading">
+        <div>
+          <p class="label">Project media</p>
+          <h2>${mediaTitle}</h2>
+        </div>
+        <p class="media-count">${mediaCount}</p>
+      </div>
       <div class="shots-grid">${shotTiles(p)}</div>
     </section>
 


### PR DESCRIPTION
## What changed
- Fixed the project-media reveal behavior that left very tall video sections transparent.
- Added a clear “Watch all videos” jump link and visible video counts.
- Added the correct YouTube title and a direct YouTube fallback link to every archived video.
- Removed redundant repeated cover stills from Mr. Kate, Voices of Learning, and Makeful so their video sections begin directly with a player.
- Kept the generated standalone project pages synchronized with the shared template.

## Root cause
The full media section used a 15% intersection threshold while also containing six to eight full-width players. On those very tall sections, 15% could exceed the viewport height, so the section never received its visible state even though the iframes were present.

## Validation
- Confirmed all 20 YouTube IDs are currently available and return their correct titles.
- Browser-verified Mr. Kate (8 players), Voices of Learning (6), and Makeful (6).
- Verified the video jump link lands on a visible first player.
- Verified responsive mobile player sizing and direct YouTube links.
- No browser warnings or errors.
- Page generation is idempotent; syntax and whitespace checks pass.