### PR TITLE
[codex] Refresh shared project data

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/art-and-science.html
+++ b/art-and-science.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/broadcast-package.html
+++ b/broadcast-package.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/coast-to-coast.html
+++ b/coast-to-coast.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 /* =========================================================
    DATA

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/makeful.html
+++ b/makeful.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/project.html
+++ b/project.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/short-film.html
+++ b/short-film.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js"></script>
+<script src="projects-data.js?v=20260621-video-fix"></script>
 <script>
 
 /* ----- resolve which project ----- */


### PR DESCRIPTION
## What changed
- Versioned the shared `projects-data.js` URL on the homepage, project template, and all generated project pages.

## Why
GitHub Pages caches static assets for up to ten minutes. Returning visitors could receive the newly repaired HTML while their browser reused the older project data, temporarily restoring the repeated cover frame and generic video labels.

## Validation
- Confirmed every page references `projects-data.js?v=20260621-video-fix`.
- Browser-verified Mr. Kate loads eight videos, no repeated frame, and the correct first YouTube title without requiring a hard refresh.
- Syntax and whitespace checks pass.