### PR TITLE
[codex] Rename Redwood Games project

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/broadcast-package.html
+++ b/broadcast-package.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/coast-to-coast.html
+++ b/coast-to-coast.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 /* =========================================================
    DATA
@@ -475,7 +475,7 @@ PROJECTS.forEach((p,i)=>{
          <span class="proj-ghost">${String(i+1).padStart(2,'0')}</span></div>`;
   a.innerHTML = `${cover}
     <div class="proj-meta">
-      <div class="proj-top"><span>${p.category}</span><span>${p.year}</span></div>
+      <div class="proj-top"><span>${p.category}</span>${p.year?`<span>${p.year}</span>`:''}</div>
       <h3 class="proj-title">${p.title}</h3>
       <p class="proj-sum">${p.summary}</p>
       <span class="proj-view">View project <i>↗</i></span>

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/makeful.html
+++ b/makeful.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/project.html
+++ b/project.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/projects-data.js
+++ b/projects-data.js
@@ -157,9 +157,9 @@ const PROJECTS = [
   },
   {
     slug:"redwood-games",
-    title:"Redwood Games 2019",
+    title:"Redwood Games",
     category:"Event · Apparel",
-    year:"2019",
+    year:"",
     summary:"Event identity and apparel concepts for the SXMW Redwood Games.",
     accent:["#21a6b3","#f0c43c"],
     cover:"images/redwoodgames2019-3.png",
@@ -171,7 +171,7 @@ const PROJECTS = [
       "The finished direction combined recognizable Monterey imagery with a playful illustrated style and a restrained event lockup.",
       "The restored sequence includes the original concept sheet, the resolved front-and-back design, and the final thumbnail used in the old portfolio."
     ],
-    details:[["Client","Redwood Logistics"],["Year","2019"],["Scope","Event Identity · Apparel"],["Role","Creative Direction · Design"]],
+    details:[["Client","Redwood Logistics"],["Scope","Event Identity · Apparel"],["Role","Creative Direction · Design"]],
     shots:[
       {image:"images/redwoodgames2019-2.jpeg",wide:true,fit:"contain",background:"#ffffff",aspect:"1440/1536"},
       {image:"images/redwoodgames2019-1.jpg",wide:true,fit:"contain",background:"#ffffff",aspect:"1440/717"},

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Redwood Games 2019 — Art &amp; Science</title>
+<title>Redwood Games — Art &amp; Science</title>
 <meta name="theme-color" content="#08080b">
 <meta name="author" content="Brandon Walowitz">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2308080b'/%3E%3Ccircle cx='16' cy='16' r='5.5' fill='%23e8c170'/%3E%3C/svg%3E">
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-portfolio-trim"></script>
+<script src="projects-data.js?v=20260621-redwood-games"></script>
 <script>
 
 /* ----- resolve which project ----- */
@@ -246,6 +246,7 @@ function render(p){
     : `style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})"`;
   const body = (p.body||[]).map(t=>`<p>${esc(t)}</p>`).join('');
   const details = (p.details||[]).map(([k,v])=>`<div class="row"><span>${esc(k)}</span><b>${esc(v)}</b></div>`).join('');
+  const kicker = [p.category,p.year].filter(Boolean).map(esc).join(' · ');
   const videoCount = (p.shots||[]).filter(s=>s.video).length;
   const imageCount = (p.shots||[]).filter(s=>!s.video).length;
   const mediaTitle = videoCount ? (imageCount ? 'Videos & selected frame' : 'Videos') : 'Selected frames';
@@ -273,7 +274,7 @@ function render(p){
     <header class="case-hero">
       <div class="reveal in">
         <a class="case-back" href="index.html#projects" data-cursor>← Selected projects</a>
-        <div class="case-kicker">${esc(p.category)} · ${esc(p.year)}</div>
+        <div class="case-kicker">${kicker}</div>
         <h1>${esc(p.title)}</h1>
         <p class="case-intro">${esc(p.intro||p.summary)}</p>
         ${mediaJump}


### PR DESCRIPTION
## What changed
- Renamed “Redwood Games 2019” to “Redwood Games.”
- Removed the visible year badge from its homepage card and case-study header.
- Removed the 2019 detail row from the project page.
- Added support for project entries without a year so no empty separator appears.
- Versioned the shared project data URL so the rename appears immediately for returning visitors.

## Validation
- Browser-verified the homepage card, page title, heading, header metadata, and project facts contain no 2019 reference.
- Confirmed all three project frames remain intact.
- Page generation is idempotent; syntax and whitespace checks pass.