### PR TITLE
[codex] Remove AI sales placeholder frame

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 /* =========================================================
    DATA

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/makeful.html
+++ b/makeful.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/project.html
+++ b/project.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/projects-data.js
+++ b/projects-data.js
@@ -352,9 +352,6 @@ const PROJECTS = [
       "The tools teach industry language, help people work through difficult questions, and create a safe place to practice calls with clear feedback.",
       "The original page relied on placeholder supporting visuals, so this restored entry keeps the written case-study structure while awaiting final product screenshots."
     ],
-    details:[["Sector","Logistics Sales"],["Period","Archived work"],["Scope","AI Tools · Training · UX"],["Role","Strategy · Product Build"]],
-    shots:[
-      {image:"C2C_Logo-hires-alpha-white.png",wide:true,fit:"contain",background:"#16374d",aspect:"16/9"}
-    ]
+    details:[["Sector","Logistics Sales"],["Period","Archived work"],["Scope","AI Tools · Training · UX"],["Role","Strategy · Product Build"]]
   }
 ];

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,7 +187,7 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-ai-sales-header"></script>
+<script src="projects-data.js?v=20260621-ai-sales-clean"></script>
 <script>
 
 /* ----- resolve which project ----- */


### PR DESCRIPTION
## What changed
- Removed the remaining Coast to Coast logo frame from the AI Sales & Onboarding Coaches project page.
- The project page now flows directly from its blurb/details to the next-project link, matching SYNERGY HomeCare.
- Kept the Coast to Coast logo on the homepage project thumbnail.
- Kept the dark blue “A” treatment in the project-page hero.
- Versioned the shared project-data URL so returning visitors receive the change immediately.

## Validation
- Browser-verified the homepage thumbnail still displays the Coast to Coast logo.
- Verified the project page has no media section and zero frame elements.
- Verified the “A” hero remains and the next-project spacing is compact.
- No browser errors or warnings.
- Page generation is idempotent; syntax and whitespace checks pass.