### PR TITLE
[codex] Refresh cached project pages

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/index.html
+++ b/index.html
@@ -411,11 +411,12 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 /* =========================================================
    DATA
 ========================================================= */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const DISCIPLINES = [
   ["01","Brand Strategy","Positioning, naming, and identity systems built to scale — the logic beneath the look. Rebrands, umbrella architectures, and the story that ties it together."],
   ["02","Graphic Design","Editorial, packaging, decks, and brand collateral with a designer's eye for type, hierarchy, and restraint. Pixel-considered, print-ready."],
@@ -464,7 +465,7 @@ const galleryGrid=document.getElementById('galleryGrid');
 PROJECTS.forEach((p,i)=>{
   const a=document.createElement('a');
   a.className='proj reveal';
-  a.href=`${p.slug}.html`;
+  a.href=`${p.slug}.html?v=${PROJECT_PAGE_VERSION}`;
   a.setAttribute('data-cursor','');
   const coverFit = p.coverFit ? `background-size:${p.coverFit};background-repeat:no-repeat;` : '';
   const coverPosition = p.coverPosition ? `background-position:${p.coverPosition};` : '';

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/makeful.html
+++ b/makeful.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/project.html
+++ b/project.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,10 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy"></script>
+<script src="projects-data.js?v=20260621-case-copy-2"></script>
 <script>
 
 /* ----- resolve which project ----- */
+const PROJECT_PAGE_VERSION='20260621-case-copy-2';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');
@@ -297,7 +298,7 @@ function render(p){
     ${mediaSection}
 
     <section class="case-next">
-      <a class="next-link reveal" href="${next.slug}.html" data-cursor>
+      <a class="next-link reveal" href="${next.slug}.html?v=${PROJECT_PAGE_VERSION}" data-cursor>
         <p class="label">Next project</p>
         <h2>${esc(next.title)} ↗</h2>
       </a>


### PR DESCRIPTION
## What changed
- Added a version to every homepage project-page link.
- Added the same version to every “Next project” link.
- Advanced the shared project-data version again.

## Why
The current Outstanding source and live data already contain the revised client-facing copy, but an older cached HTML page could continue requesting the prior data URL and display the removed “archived contact sheet” and “restored frame” wording. Versioning both the page links and shared data prevents normal site navigation from reopening that stale page.

## Validation
- Confirmed the Outstanding source contains neither reported sentence.
- Browser-verified the homepage links to `outstanding.html?v=20260621-case-copy-2`.
- Verified that versioned page renders the new motion-design copy and a versioned next-project link.
- No browser errors or warnings.
- Page generation is idempotent; syntax and whitespace checks pass.