### PR TITLE
[codex] Refine Roots Logistics branding project

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/index.html
+++ b/index.html
@@ -411,12 +411,12 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 /* =========================================================
    DATA
 ========================================================= */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const DISCIPLINES = [
   ["01","Brand Strategy","Positioning, naming, and identity systems built to scale — the logic beneath the look. Rebrands, umbrella architectures, and the story that ties it together."],
   ["02","Graphic Design","Editorial, packaging, decks, and brand collateral with a designer's eye for type, hierarchy, and restraint. Pixel-considered, print-ready."],

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/makeful.html
+++ b/makeful.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/project.html
+++ b/project.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/projects-data.js
+++ b/projects-data.js
@@ -297,24 +297,23 @@ const PROJECTS = [
   {
     slug:"roots-logistics-identity",
     title:"Roots Logistics Identity",
-    category:"Brand Identity",
+    category:"Branding",
     year:"",
-    summary:"A clean logistics identity centered on a directional green arrow.",
+    summary:"A clean logistics brand centered on a directional green arrow.",
     accent:["#1d9143","#efefef"],
     cover:"images/roots-2.png",
     coverFit:"contain",
     coverBackground:"#eeeeee",
-    intro:"A direct, modern identity for a logistics brand built around movement and direction.",
+    intro:"A direct, modern brand system built around movement and direction.",
     body:[
       "The Roots Logistics identity uses a minimal wordmark and a bold directional device.",
       "The green arrow creates a clear signal of movement and progress, giving the system a recognizable device that works independently or alongside the wordmark.",
-      "The identity extends into presentation graphics and fleet photography with a clean, practical visual language suited to a logistics business."
+      "The brand extends into fleet photography with a clean, practical visual language suited to a logistics business."
     ],
-    details:[["Client","Roots Logistics"],["Scope","Logo · Identity"],["Role","Brand Design"]],
+    details:[["Client","Roots Logistics"],["Scope","Branding · Logo · Identity"],["Role","Brand Design"]],
     shots:[
       {image:"images/roots-2.png",fit:"contain",background:"#eeeeee"},
-      {image:"images/roots-1.png",wide:true,fit:"contain",background:"#ffffff",aspect:"945/764"},
-      {image:"images/roots-presentation-1.png",fit:"contain",background:"#dbeaf2"}
+      {image:"images/roots-1.png",wide:true,fit:"contain",background:"#ffffff",aspect:"945/764"}
     ]
   },
   {

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-case-copy-2"></script>
+<script src="projects-data.js?v=20260621-roots-branding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-case-copy-2';
+const PROJECT_PAGE_VERSION='20260621-roots-branding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');


### PR DESCRIPTION
## What changed
- Reclassified Roots Logistics Identity as a branding project.
- Updated the summary, introduction, supporting copy, and scope to emphasize branding rather than presentation design.
- Removed the presentation artwork from the Roots Logistics Identity media section.
- Kept exactly two frames: the padded Roots logo and the brand applied with the trucks.
- Left the separately named Roots Logistics Presentation project unchanged.
- Versioned project navigation and shared data so returning visitors receive the update immediately.

## Validation
- Browser-verified the homepage card is labeled “Branding.”
- Verified the project page reports two frames and displays only `roots-2.png` and `roots-1.png`.
- Confirmed `roots-presentation-1.png` is absent from the branding page.
- No browser errors or warnings.
- Page generation is idempotent; syntax and whitespace checks pass.