### PR TITLE
[codex] Remove unpadded Roots logo

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/index.html
+++ b/index.html
@@ -411,12 +411,12 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 /* =========================================================
    DATA
 ========================================================= */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const DISCIPLINES = [
   ["01","Brand Strategy","Positioning, naming, and identity systems built to scale — the logic beneath the look. Rebrands, umbrella architectures, and the story that ties it together."],
   ["02","Graphic Design","Editorial, packaging, decks, and brand collateral with a designer's eye for type, hierarchy, and restraint. Pixel-considered, print-ready."],

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/makeful.html
+++ b/makeful.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/project.html
+++ b/project.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/projects-data.js
+++ b/projects-data.js
@@ -309,12 +309,11 @@ const PROJECTS = [
     body:[
       "The Roots Logistics identity uses a minimal wordmark and a bold directional device.",
       "The green arrow creates a clear signal of movement and progress, giving the system a recognizable device that works independently or alongside the wordmark.",
-      "The brand extends into fleet photography with a clean, practical visual language suited to a logistics business."
+      "The final lockup balances a straightforward wordmark with the directional symbol, creating a flexible identity that can scale cleanly across brand applications."
     ],
     details:[["Client","Roots Logistics"],["Scope","Branding · Logo · Identity"],["Role","Brand Design"]],
     shots:[
-      {image:"images/roots-2.png",fit:"contain",background:"#eeeeee"},
-      {image:"images/roots-1.png",wide:true,fit:"contain",background:"#ffffff",aspect:"945/764"}
+      {image:"images/roots-2.png",fit:"contain",background:"#eeeeee"}
     ]
   },
   {

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-sarah-crop"></script>
+<script src="projects-data.js?v=20260621-roots-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-sarah-crop';
+const PROJECT_PAGE_VERSION='20260621-roots-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');


### PR DESCRIPTION
Removes the oversized, unpadded second image from the Roots Logistics Identity project page.

Also updates the project copy to describe the remaining logo work and refreshes project-page cache versions. The separate Roots Logistics Presentation project is unchanged.

Validation:
- Roots identity renders exactly one frame
- Remaining frame is `images/roots-2.png`
- Homepage thumbnail still uses the padded Roots logo
- Generated project pages are idempotent
- JavaScript syntax and local visual checks pass