### PR TITLE
[codex] Pad project logo thumbnails

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/index.html
+++ b/index.html
@@ -411,12 +411,12 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 /* =========================================================
    DATA
 ========================================================= */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const DISCIPLINES = [
   ["01","Brand Strategy","Positioning, naming, and identity systems built to scale — the logic beneath the look. Rebrands, umbrella architectures, and the story that ties it together."],
   ["02","Graphic Design","Editorial, packaging, decks, and brand collateral with a designer's eye for type, hierarchy, and restraint. Pixel-considered, print-ready."],
@@ -469,9 +469,10 @@ PROJECTS.forEach((p,i)=>{
   a.setAttribute('data-cursor','');
   const coverFit = p.coverFit ? `background-size:${p.coverFit};background-repeat:no-repeat;` : '';
   const coverPosition = p.coverPosition ? `background-position:${p.coverPosition};` : '';
+  const coverPadding = p.coverPadding ? `padding:${p.coverPadding};background-origin:content-box;` : '';
   const coverBackground = p.coverBackground ? `background-color:${p.coverBackground};` : '';
   const cover = p.cover
-    ? `<div class="proj-cover" style="background-image:url('${p.cover}');${coverFit}${coverPosition}${coverBackground}"></div>`
+    ? `<div class="proj-cover" style="background-image:url('${p.cover}');${coverFit}${coverPosition}${coverPadding}${coverBackground}"></div>`
     : `<div class="proj-cover" style="background:linear-gradient(140deg,${p.accent[0]},${p.accent[1]})">
          <span class="proj-ghost">${String(i+1).padStart(2,'0')}</span></div>`;
   a.innerHTML = `${cover}

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/makeful.html
+++ b/makeful.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/project.html
+++ b/project.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/projects-data.js
+++ b/projects-data.js
@@ -325,6 +325,7 @@ const PROJECTS = [
     accent:["#1f5e5a","#0b2225"],
     cover:"images/synergy-logo.svg",
     coverFit:"contain",
+    coverPadding:"35px",
     coverBackground:"#1f5e5a",
     intro:"Turning a local home-care franchise into a measurable, repeatable growth machine.",
     body:[
@@ -343,6 +344,7 @@ const PROJECTS = [
     accent:["#28496a","#10202d"],
     cover:"C2C_Logo-hires-alpha-white.png",
     coverFit:"contain",
+    coverPadding:"35px",
     coverBackground:"#16374d",
     caseCover:false,
     intro:"Training that feels like a coach, not a script.",

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-roots-padding"></script>
+<script src="projects-data.js?v=20260621-logo-padding"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-roots-padding';
+const PROJECT_PAGE_VERSION='20260621-logo-padding';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');


### PR DESCRIPTION
Adds a 35px inset around the SYNERGY HomeCare and Coast to Coast logos in their homepage project thumbnails so the artwork no longer touches the card edges.

The padding is data-driven, preserves each logo's proportions, and applies only to those two cards. Project-page cache versions were refreshed so the update appears immediately after deployment.

Validation:
- Both target thumbnails compute to 35px padding
- Background images use the content box and retain `contain` sizing
- Desktop and mobile layouts checked visually
- No browser console errors
- JavaScript syntax passes
- Generated project pages are idempotent