### PR TITLE
[codex] Remove Synergy project logo

### DIFF
--- a/abled.html
+++ b/abled.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ai-sales-coaches.html
+++ b/ai-sales-coaches.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/be-kind-by-ellen.html
+++ b/be-kind-by-ellen.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/ellen-shop.html
+++ b/ellen-shop.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/index.html
+++ b/index.html
@@ -411,12 +411,12 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 /* =========================================================
    DATA
 ========================================================= */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const DISCIPLINES = [
   ["01","Brand Strategy","Positioning, naming, and identity systems built to scale — the logic beneath the look. Rebrands, umbrella architectures, and the story that ties it together."],
   ["02","Graphic Design","Editorial, packaging, decks, and brand collateral with a designer's eye for type, hierarchy, and restraint. Pixel-considered, print-ready."],

--- a/lightifier.html
+++ b/lightifier.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/makeful.html
+++ b/makeful.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/mr-kate.html
+++ b/mr-kate.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/outstanding.html
+++ b/outstanding.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/project.html
+++ b/project.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/projects-data.js
+++ b/projects-data.js
@@ -327,6 +327,7 @@ const PROJECTS = [
     coverFit:"contain",
     coverPadding:"35px",
     coverBackground:"#1f5e5a",
+    caseCover:false,
     intro:"Turning a local home-care franchise into a measurable, repeatable growth machine.",
     body:[
       "SYNERGY HomeCare needed more than impressions — it needed booked consultations. The work began with the funnel: who is searching, what matters most to them, and what helps them feel ready to call.",

--- a/redwood-games.html
+++ b/redwood-games.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-logistics.html
+++ b/redwood-logistics.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/redwood-sales-collateral.html
+++ b/redwood-sales-collateral.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-identity.html
+++ b/roots-logistics-identity.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/roots-logistics-presentation.html
+++ b/roots-logistics-presentation.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/synergy-homecare.html
+++ b/synergy-homecare.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');

--- a/voices-of-learning.html
+++ b/voices-of-learning.html
@@ -187,11 +187,11 @@
 </footer>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-<script src="projects-data.js?v=20260621-logo-padding"></script>
+<script src="projects-data.js?v=20260621-synergy-case"></script>
 <script>
 
 /* ----- resolve which project ----- */
-const PROJECT_PAGE_VERSION='20260621-logo-padding';
+const PROJECT_PAGE_VERSION='20260621-synergy-case';
 const params=new URLSearchParams(location.search);
 const fileSlug=location.pathname.split('/').pop().replace(/\.html$/,'');
 const id=document.body.dataset.project || params.get('id') || (fileSlug!=='project' ? fileSlug : '');


### PR DESCRIPTION
Removes the SYNERGY logo from the individual project page and replaces that project-page cover with the existing branded gradient and initial treatment.

The homepage project thumbnail remains unchanged and continues to show the SYNERGY logo with its 35px inset.

Validation:
- Project page contains no SYNERGY logo asset
- Project cover renders the green gradient with the “S” treatment
- Homepage thumbnail retains the padded logo
- No browser console errors
- JavaScript syntax passes
- Generated project pages are idempotent